### PR TITLE
feature/e2.1 registers

### DIFF
--- a/TP3-CPU-RISCV/rtl/core/ID/register_file.v
+++ b/TP3-CPU-RISCV/rtl/core/ID/register_file.v
@@ -1,0 +1,64 @@
+`timescale 1ns / 1ps
+`default_nettype none
+
+//==============================================================================
+// Módulo: register_file
+// Descripción: Banco de registros para la etapa ID del procesador RISC-V.
+//   - 32 registros de 32 bits.
+//   - Registro x0 siempre lee 0.
+//   - Internal Forwarding (Write-Through): Permite leer el dato actualizado
+//     en el mismo ciclo en el que se escribe (simulando escritura en la 1ra
+//     mitad del ciclo y lectura en la 2da mitad).
+//==============================================================================
+
+module register_file (
+    input  wire        i_clk,
+    input  wire        i_rst,
+    
+    // Señales de Control
+    input  wire        i_reg_write,
+    
+    // Direcciones
+    input  wire [4:0]  i_read_reg1,
+    input  wire [4:0]  i_read_reg2,
+    input  wire [4:0]  i_write_reg,
+    
+    // Datos
+    input  wire [31:0] i_write_data,
+
+    output wire [31:0] o_read_data1,
+    output wire [31:0] o_read_data2
+);
+
+    reg [31:0] registers [0:31];
+    integer i;
+
+    // Escritura Sincrónica
+    always @(posedge i_clk) begin
+        if (i_rst) begin
+            for (i = 0; i < 32; i = i + 1) begin
+                registers[i] <= 32'd0;
+            end
+        end else begin
+            if (i_reg_write && (i_write_reg != 5'd0)) begin
+                registers[i_write_reg] <= i_write_data;
+            end
+        end
+    end
+
+    // Lectura Combinacional con Internal Forwarding (Write-Through)
+    // 1. Si el registro es 0, devuelve 0.
+    // 2. Si hay una escritura activa al mismo registro que se quiere leer, 
+    //    devuelve el i_write_data directamente (dato nuevo).
+    // 3. Si no, devuelve el valor almacenado en la memoria (dato viejo).
+    
+    assign o_read_data1 = (i_read_reg1 == 5'd0) ? 32'd0 :
+                          (i_reg_write && (i_write_reg == i_read_reg1)) ? i_write_data :
+                          registers[i_read_reg1];
+
+    assign o_read_data2 = (i_read_reg2 == 5'd0) ? 32'd0 :
+                          (i_reg_write && (i_write_reg == i_read_reg2)) ? i_write_data :
+                          registers[i_read_reg2];
+
+endmodule
+`default_nettype wire

--- a/TP3-CPU-RISCV/rtl/core/ID/register_file.v
+++ b/TP3-CPU-RISCV/rtl/core/ID/register_file.v
@@ -7,27 +7,32 @@
 //   - 32 registros de 32 bits.
 //   - Registro x0 siempre lee 0.
 //   - Internal Forwarding (Write-Through): Permite leer el dato actualizado
-//     en el mismo ciclo en el que se escribe (simulando escritura en la 1ra
-//     mitad del ciclo y lectura en la 2da mitad).
+//     en el mismo ciclo en el que se escribe.
+//   - Puerto de Depuración: Permite a la UART leer el estado de los registros.
 //==============================================================================
 
 module register_file (
     input  wire        i_clk,
     input  wire        i_rst,
     
-    // Señales de Control
+    // Señales de Control (Datapath)
     input  wire        i_reg_write,
     
-    // Direcciones
+    // Direcciones (Datapath)
     input  wire [4:0]  i_read_reg1,
     input  wire [4:0]  i_read_reg2,
     input  wire [4:0]  i_write_reg,
     
-    // Datos
+    // Datos (Datapath)
     input  wire [31:0] i_write_data,
 
     output wire [31:0] o_read_data1,
-    output wire [31:0] o_read_data2
+    output wire [31:0] o_read_data2,
+
+    // Puerto de Depuración (Debug Unit / UART)
+    input  wire        i_debug_re,       // Habilitación de lectura debug
+    input  wire [4:0]  i_debug_reg_addr, // Dirección del registro a leer (0 a 31)
+    output reg  [31:0] o_debug_reg_data  // Dato enviado a la UART
 );
 
     reg [31:0] registers [0:31];
@@ -46,12 +51,20 @@ module register_file (
         end
     end
 
-    // Lectura Combinacional con Internal Forwarding (Write-Through)
-    // 1. Si el registro es 0, devuelve 0.
-    // 2. Si hay una escritura activa al mismo registro que se quiere leer, 
-    //    devuelve el i_write_data directamente (dato nuevo).
-    // 3. Si no, devuelve el valor almacenado en la memoria (dato viejo).
-    
+    // Lectura Sincrónica para Depuración (UART)
+    // Se hace sincrónica para no sumar retardo combinacional al pipeline principal.
+    always @(posedge i_clk) begin
+        if (i_debug_re) begin
+            // Mantenemos la regla de que x0 siempre vale 0, incluso en debug
+            if (i_debug_reg_addr == 5'd0) begin
+                o_debug_reg_data <= 32'd0;
+            end else begin
+                o_debug_reg_data <= registers[i_debug_reg_addr];
+            end
+        end
+    end
+
+    // Lectura Combinacional con Internal Forwarding (Write-Through) para Datapath
     assign o_read_data1 = (i_read_reg1 == 5'd0) ? 32'd0 :
                           (i_reg_write && (i_write_reg == i_read_reg1)) ? i_write_data :
                           registers[i_read_reg1];

--- a/TP3-CPU-RISCV/tb/register_tb.v
+++ b/TP3-CPU-RISCV/tb/register_tb.v
@@ -1,0 +1,157 @@
+`timescale 1ns / 1ps
+`default_nettype none
+
+module tb_register_file();
+
+    // Declaración de señales
+    reg         clk;
+    reg         rst;
+    reg         reg_write;
+    reg  [4:0]  read_reg1;
+    reg  [4:0]  read_reg2;
+    reg  [4:0]  write_reg;
+    reg  [31:0] write_data;
+
+    wire [31:0] read_data1;
+    wire [31:0] read_data2;
+
+    // Instanciación del Módulo
+    register_file uut (
+        .i_clk(clk),
+        .i_rst(rst),
+        .i_reg_write(reg_write),
+        .i_read_reg1(read_reg1),
+        .i_read_reg2(read_reg2),
+        .i_write_reg(write_reg),
+        .i_write_data(write_data),
+        .o_read_data1(read_data1),
+        .o_read_data2(read_data2)
+    );
+
+    // Generación del Reloj (Periodo de 10ns -> 100MHz)
+    always #5 clk = ~clk;
+
+    // Estímulos de Prueba
+    initial begin
+        // Inicialización de señales
+        clk = 0;
+        rst = 1;
+        reg_write = 0;
+        read_reg1 = 0;
+        read_reg2 = 0;
+        write_reg = 0;
+        write_data = 0;
+
+        $display("--- INICIO DE PRUEBAS DEL BANCO DE REGISTROS ---");
+
+        // Dejar pasar un par de ciclos y soltar el reset
+        #20;
+        rst = 0;
+
+        // ---------------------------------------------------------
+        // PRUEBA 1: Escritura y Lectura Normal
+        // ---------------------------------------------------------
+        $display("[Test 1] Escribiendo 32'hAAAA_AAAA en x5 y 32'h5555_5555 en x10");
+        
+        // Escribir en x5
+        reg_write = 1; 
+        write_reg = 5; 
+        write_data = 32'hAAAA_AAAA;
+        #10; // Esperar un ciclo de reloj para que se guarde
+
+        // Escribir en x10
+        write_reg = 10; 
+        write_data = 32'h5555_5555;
+        #10;
+        
+        // Detener escritura y proceder a leer ambos registros a la vez
+        reg_write = 0;
+        read_reg1 = 5;
+        read_reg2 = 10;
+        #5; // Pequeña demora para que la lógica combinacional se asiente
+        
+        if (read_data1 == 32'hAAAA_AAAA && read_data2 == 32'h5555_5555)
+            $display("-> EXITO: Lectura correcta de x5 y x10.");
+        else
+            $display("-> ERROR: Datos incorrectos. read1=%h, read2=%h", read_data1, read_data2);
+            
+        // ---------------------------------------------------------
+        // PRUEBA 2: Internal Forwarding (Write-Through)
+        // ---------------------------------------------------------
+        // Vamos a escribir en el registro x15 y pedir leerlo en el MISMO ciclo
+        $display("\n[Test 2] Probando Internal Forwarding en x15");
+        #5;
+        
+        reg_write = 1;
+        write_reg = 15;
+        write_data = 32'hDEAD_BEEF;
+        
+        read_reg1 = 15; // Pedimos leer x15 mientras i_reg_write está en 1
+        
+        #1; // Esperamos solo 1ns (mucho menos que un ciclo de reloj)
+        if (read_data1 == 32'hDEAD_BEEF)
+            $display("-> EXITO: El dato fresco (DEAD_BEEF) fluye instantaneamente a la salida.");
+        else
+            $display("-> ERROR: Internal Forwarding fallido. read1=%h", read_data1);
+            
+        #9; // Completar el ciclo de reloj
+
+        // ---------------------------------------------------------
+        // PRUEBA 3: Protección del registro x0
+        // ---------------------------------------------------------
+        $display("\n[Test 3] Intentando escribir en el registro x0");
+        
+        reg_write = 1;
+        write_reg = 0;
+        write_data = 32'hFFFF_FFFF;
+        
+        read_reg1 = 0; // Intentamos leer x0 al mismo tiempo (a ver si el forwarding lo pisa)
+        
+        #1; // Esperar lógica combinacional
+        if (read_data1 == 32'h0000_0000)
+            $display("-> EXITO: x0 mantiene el valor cero durante la escritura.");
+        else
+            $display("-> ERROR: x0 se dejo sobreescribir por forwarding. read1=%h", read_data1);
+            
+        #9; // Completar ciclo
+        reg_write = 0; // Detener escritura
+        #5; 
+        
+        if (read_data1 == 32'h0000_0000)
+            $display("-> EXITO: x0 mantiene el valor cero de forma permanente en memoria.");
+        else
+            $display("-> ERROR: x0 cambio en memoria. read1=%h", read_data1);
+
+        // -------------------------------------------------------------
+        // PRUEBA 4: Escribir un registro y leer otro en el mismo ciclo
+        // -------------------------------------------------------------
+        $display("\n[Test 4] Escribir x20 y leer x5 y x10 en el mismo ciclo");    
+        reg_write = 1;
+        write_reg = 20;
+        write_data = 32'h1234_5678;
+
+        read_reg1 = 5;  // x5 debería seguir siendo AAAA_AAAA
+        read_reg2 = 10; // x10 debería seguir siendo 5555_555
+
+        #1; // Esperar lógica combinacional
+        if (read_data1 == 32'hAAAA_AAAA && read_data2 == 32'h5555_5555)
+            $display("-> EXITO: Lectura correcta de x5 y x10 mientras se escribe x20.");
+        else
+            $display("-> ERROR: Datos incorrectos durante escritura de x20. read1=%h, read2=%h", read_data1, read_data2);
+
+        // Leer x20 en el siguiente ciclo para confirmar que se escribió correctamente
+        #9; // Completar ciclo
+        read_reg1 = 20; // Ahora leemos x20
+        #1; // Esperar lógica combinacional
+        if (read_data1 == 32'h1234_5678)
+            $display("-> EXITO: x20 fue escrito correctamente y se puede leer ahora.");
+        else
+            $display("-> ERROR: x20 no contiene el valor esperado. read1=%h", read_data1);
+
+        $display("\n--- FIN DE LAS PRUEBAS ---");
+        #20;
+        $finish;
+    end
+
+endmodule
+`default_nettype wire

--- a/TP3-CPU-RISCV/tb/register_tb.v
+++ b/TP3-CPU-RISCV/tb/register_tb.v
@@ -3,7 +3,7 @@
 
 module tb_register_file();
 
-    // Declaración de señales
+    // Declaración de señales principales
     reg         clk;
     reg         rst;
     reg         reg_write;
@@ -15,6 +15,11 @@ module tb_register_file();
     wire [31:0] read_data1;
     wire [31:0] read_data2;
 
+    // Declaración de señales del puerto de depuración
+    reg         debug_re;
+    reg  [4:0]  debug_reg_addr;
+    wire [31:0] debug_reg_data;
+
     // Instanciación del Módulo
     register_file uut (
         .i_clk(clk),
@@ -25,7 +30,10 @@ module tb_register_file();
         .i_write_reg(write_reg),
         .i_write_data(write_data),
         .o_read_data1(read_data1),
-        .o_read_data2(read_data2)
+        .o_read_data2(read_data2),
+        .i_debug_re(debug_re),
+        .i_debug_reg_addr(debug_reg_addr),
+        .o_debug_reg_data(debug_reg_data)
     );
 
     // Generación del Reloj (Periodo de 10ns -> 100MHz)
@@ -41,6 +49,10 @@ module tb_register_file();
         read_reg2 = 0;
         write_reg = 0;
         write_data = 0;
+        
+        // Inicialización de debug
+        debug_re = 0;
+        debug_reg_addr = 0;
 
         $display("--- INICIO DE PRUEBAS DEL BANCO DE REGISTROS ---");
 
@@ -53,22 +65,19 @@ module tb_register_file();
         // ---------------------------------------------------------
         $display("[Test 1] Escribiendo 32'hAAAA_AAAA en x5 y 32'h5555_5555 en x10");
         
-        // Escribir en x5
         reg_write = 1; 
         write_reg = 5; 
         write_data = 32'hAAAA_AAAA;
-        #10; // Esperar un ciclo de reloj para que se guarde
+        #10;
 
-        // Escribir en x10
         write_reg = 10; 
         write_data = 32'h5555_5555;
         #10;
         
-        // Detener escritura y proceder a leer ambos registros a la vez
         reg_write = 0;
         read_reg1 = 5;
         read_reg2 = 10;
-        #5; // Pequeña demora para que la lógica combinacional se asiente
+        #5; 
         
         if (read_data1 == 32'hAAAA_AAAA && read_data2 == 32'h5555_5555)
             $display("-> EXITO: Lectura correcta de x5 y x10.");
@@ -78,7 +87,6 @@ module tb_register_file();
         // ---------------------------------------------------------
         // PRUEBA 2: Internal Forwarding (Write-Through)
         // ---------------------------------------------------------
-        // Vamos a escribir en el registro x15 y pedir leerlo en el MISMO ciclo
         $display("\n[Test 2] Probando Internal Forwarding en x15");
         #5;
         
@@ -86,15 +94,15 @@ module tb_register_file();
         write_reg = 15;
         write_data = 32'hDEAD_BEEF;
         
-        read_reg1 = 15; // Pedimos leer x15 mientras i_reg_write está en 1
+        read_reg1 = 15; 
         
-        #1; // Esperamos solo 1ns (mucho menos que un ciclo de reloj)
+        #1; 
         if (read_data1 == 32'hDEAD_BEEF)
             $display("-> EXITO: El dato fresco (DEAD_BEEF) fluye instantaneamente a la salida.");
         else
             $display("-> ERROR: Internal Forwarding fallido. read1=%h", read_data1);
             
-        #9; // Completar el ciclo de reloj
+        #9; 
 
         // ---------------------------------------------------------
         // PRUEBA 3: Protección del registro x0
@@ -105,16 +113,16 @@ module tb_register_file();
         write_reg = 0;
         write_data = 32'hFFFF_FFFF;
         
-        read_reg1 = 0; // Intentamos leer x0 al mismo tiempo (a ver si el forwarding lo pisa)
+        read_reg1 = 0; 
         
-        #1; // Esperar lógica combinacional
+        #1; 
         if (read_data1 == 32'h0000_0000)
             $display("-> EXITO: x0 mantiene el valor cero durante la escritura.");
         else
             $display("-> ERROR: x0 se dejo sobreescribir por forwarding. read1=%h", read_data1);
             
-        #9; // Completar ciclo
-        reg_write = 0; // Detener escritura
+        #9; 
+        reg_write = 0; 
         #5; 
         
         if (read_data1 == 32'h0000_0000)
@@ -130,23 +138,66 @@ module tb_register_file();
         write_reg = 20;
         write_data = 32'h1234_5678;
 
-        read_reg1 = 5;  // x5 debería seguir siendo AAAA_AAAA
-        read_reg2 = 10; // x10 debería seguir siendo 5555_555
+        read_reg1 = 5;  
+        read_reg2 = 10; 
 
-        #1; // Esperar lógica combinacional
+        #1; 
         if (read_data1 == 32'hAAAA_AAAA && read_data2 == 32'h5555_5555)
             $display("-> EXITO: Lectura correcta de x5 y x10 mientras se escribe x20.");
         else
             $display("-> ERROR: Datos incorrectos durante escritura de x20. read1=%h, read2=%h", read_data1, read_data2);
 
-        // Leer x20 en el siguiente ciclo para confirmar que se escribió correctamente
-        #9; // Completar ciclo
-        read_reg1 = 20; // Ahora leemos x20
-        #1; // Esperar lógica combinacional
+        #9; 
+        read_reg1 = 20; 
+        #1; 
         if (read_data1 == 32'h1234_5678)
             $display("-> EXITO: x20 fue escrito correctamente y se puede leer ahora.");
         else
             $display("-> ERROR: x20 no contiene el valor esperado. read1=%h", read_data1);
+            
+        #9;
+        reg_write = 0;
+
+        // -------------------------------------------------------------
+        // PRUEBA 5: Lectura a través de la Debug Unit (Sincrónica)
+        // -------------------------------------------------------------
+        $display("\n[Test 5] Verificando lecturas de la Debug Unit (UART)");
+        
+        debug_re = 1; // Habilitamos el puerto de lectura debug
+        
+        // Verificamos x0
+        debug_reg_addr = 0;
+        #10; // Esperamos 1 ciclo (posedge)
+        if (debug_reg_data == 32'h0000_0000)
+            $display("-> EXITO: Debug leyo x0 correctamente.");
+        else
+            $display("-> ERROR: Debug fallo en x0. Dato leido: %h", debug_reg_data);
+
+        // Verificamos x5 (Escrito en Prueba 1)
+        debug_reg_addr = 5;
+        #10;
+        if (debug_reg_data == 32'hAAAA_AAAA)
+            $display("-> EXITO: Debug leyo x5 correctamente (AAAA_AAAA).");
+        else
+            $display("-> ERROR: Debug fallo en x5. Dato leido: %h", debug_reg_data);
+
+        // Verificamos x15 (Escrito en Prueba 2)
+        debug_reg_addr = 15;
+        #10;
+        if (debug_reg_data == 32'hDEAD_BEEF)
+            $display("-> EXITO: Debug leyo x15 correctamente (DEAD_BEEF).");
+        else
+            $display("-> ERROR: Debug fallo en x15. Dato leido: %h", debug_reg_data);
+
+        // Verificamos x20 (Escrito en Prueba 4)
+        debug_reg_addr = 20;
+        #10;
+        if (debug_reg_data == 32'h1234_5678)
+            $display("-> EXITO: Debug leyo x20 correctamente (1234_5678).");
+        else
+            $display("-> ERROR: Debug fallo en x20. Dato leido: %h", debug_reg_data);
+
+        debug_re = 0;
 
         $display("\n--- FIN DE LAS PRUEBAS ---");
         #20;


### PR DESCRIPTION
# Implementación del Banco de Registros (`register_file`) con Internal Forwarding y Puerto Debug

## Descripción

Se implementa el módulo del Banco de Registros (`register_file`) correspondiente a la etapa de Decodificación de Instrucciones (**ID**) del procesador RISC-V de 5 etapas. El diseño incluye lógica de reenvío interno (*Write-Through / Internal Forwarding*) para mitigar riesgos estructurales de datos y un puerto dedicado para la inspección serie de registros vía **UART (Debug Unit)**.

---

## Cambios principales

### Módulo `register_file.v`:
* **Capacidad**: Array de 32 registros de 32 bits.
* **Protección de `x0`**: Hardwired a cero. Se bloquea cualquier intento de escritura sobre `x0` y se fuerza el valor `32'd0` en sus lecturas.
* **Escritura sincrónica y lectura combinacional**: Permite que los operandos estén disponibles en el mismo ciclo dentro del datapath.
* **Internal Forwarding (Write-Through)**: Si se intenta leer un registro en el mismo ciclo en que la etapa WB está escribiendo sobre él, la lógica redirige combinacionalmente el dato entrante (`i_write_data`) a la salida sin esperar al siguiente flanco de reloj.
* **Puerto de Depuración (UART)**: Se incorporan las señales `i_debug_re`, `i_debug_reg_addr` y `o_debug_reg_data` para lectura sincrónica secuencial de los 32 registros desde la máquina de estados de depuración sin penalizar los tiempos de propagación del pipeline principal.

---

## Verificación y Pruebas en Simulación

Se ejecutó la suite de pruebas del testbench abarcando los siguientes escenarios:

1. **Escritura y Lectura Estándar**: Verificación de persistencia de datos en registros generales (`x5` y `x10`).
2. **Internal Forwarding (Write-Through)**: Confirmación de flujo de datos en tiempo real al leer y escribir sobre `x15` en el mismo ciclo de reloj.
3. **Protección de `x0`**: Intento de sobrescritura en `x0` validando que la salida se mantenga en cero tanto por lectura directa como por la lógica de forwarding.
4. **Acceso Concurrente**: Escritura en `x20` mientras se leen simultáneamente los registros `x5` y `x10`.
5. **Lectura por Debug Unit**: Validación del puerto sincrónico de depuración leyendo de forma secuencial el contenido de `x0`, `x5`, `x15` y `x20`.

---

## Resultados de Simulación

```text
--- INICIO DE PRUEBAS DEL BANCO DE REGISTROS ---
[Test 1] Escribiendo 32'hAAAA_AAAA en x5 y 32'h5555_5555 en x10
-> EXITO: Lectura correcta de x5 y x10.

[Test 2] Probando Internal Forwarding en x15
-> EXITO: El dato fresco (DEAD_BEEF) fluye instantaneamente a la salida.

[Test 3] Intentando escribir en el registro x0
-> EXITO: x0 mantiene el valor cero durante la escritura.
-> EXITO: x0 mantiene el valor cero de forma permanente en memoria.

[Test 4] Escribir x20 y leer x5 y x10 en el mismo ciclo
-> EXITO: Lectura correcta de x5 y x10 mientras se escribe x20.
-> EXITO: x20 fue escrito correctamente y se puede leer ahora.

[Test 5] Verificando lecturas de la Debug Unit (UART)
-> EXITO: Debug leyo x0 correctamente.
-> EXITO: Debug leyo x5 correctamente (AAAA_AAAA).
-> EXITO: Debug leyo x15 correctamente (DEAD_BEEF).
-> EXITO: Debug leyo x20 correctamente (1234_5678).

--- FIN DE LAS PRUEBAS ---

```